### PR TITLE
Verbose error reporting

### DIFF
--- a/MauticConnector.js
+++ b/MauticConnector.js
@@ -88,7 +88,7 @@ module.exports = class MauticConnector {
             const errors = body.errors instanceof Error ? [body.errors]
                 : (result.errors instanceof Error ? [result.errors]
                     : (body.errors instanceof Array ? body.errors
-                        : (result.errors instanceof Error) ? result.errors : []));
+                        : (result.errors instanceof Array) ? result.errors : []));
             const logMessage = 'MAUTIC | Mautic API error. | ' + errors.map(error => error.code + ': ' + error.message).join(', ');
 
             if (this._logLevel !== "none") {


### PR DESCRIPTION
The resulted body contained errors array and was not displayed in verbose mode due to mismatch in type comparison.
`{"errors":[{"message":"API authorization denied.","code":401,"type":"access_denied"}],"error":"access_denied","error_description":"API authorization denied. (`error` and `error_description` are deprecated as of 2.6.0 and will be removed in 3.0. Use the `errors` array instead.)"}`