### PR TITLE
fix array query parameter conversion

### DIFF
--- a/HttpQueryHelper.js
+++ b/HttpQueryHelper.js
@@ -32,7 +32,7 @@ class HttpQueryHelper {
      */
     convertQueryParametersToString(queryParameters = {}) {
         queryParameters = (queryParameters && (typeof queryParameters === 'object')) ? queryParameters : {};
-        return Object.entries(queryParameters).map(([key, value]) => key + '=' + (Array.isArray(value) ? encodeURIComponent(value).join(',') : encodeURIComponent(value))).join('&');
+        return Object.entries(queryParameters).map(([key, value]) => Array.isArray(value) ? value.map(v => key + '[]=' + encodeURIComponent(v)).join('&') : key + '=' + encodeURIComponent(value)).join('&');
     }
     /**
      * In the name, the two instances of the word “query” mean two different things.


### PR DESCRIPTION
```
queryParameters = {
  fields: [ 0, 1, 2, ... ]
}
```

before:
```
(node:11413) UnhandledPromiseRejectionWarning: TypeError: encodeURIComponent(...).join is not a function
    at /projects/something-with-mautic/node_modules/node-mautic/HttpQueryHelper.js:35:132
    at Array.map (<anonymous>)
    at HttpQueryHelper.convertQueryParametersToString (/projects/something-with-mautic/node_modules/node-mautic/HttpQueryHelper.js:35:48)
    at MauticConnector._makeUrl (/projects/something-with-mautic/node_modules/node-mautic/MauticConnector.js:170:51)
    at Object.deleteFormFields (/projects/something-with-mautic/node_modules/node-mautic/MauticConnector.js:363:103)
    at deleteAllFields (/projects/something-with-mautic/mautic.js:48:22)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:11413) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:11413) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

after:
```
fields[]=0&fields[]=1&fields[]=2&...
```